### PR TITLE
Loader for runtime code added

### DIFF
--- a/dolabra/analysis/symbolic.py
+++ b/dolabra/analysis/symbolic.py
@@ -15,10 +15,14 @@ from mythril.laser.plugin.plugins import (
     InstructionProfilerBuilder,
 )
 
+import mythril.laser.ethereum.state.account
+
 from dolabra.analysis.module.modules.loader import ModuleLoader
 from dolabra.logger.log_manager import setup_logger
 from dolabra.contract_loaders.file_loader import FileLoader
 from dolabra.contract_loaders.jsonrpc_loader import JsonRpcLoader
+from dolabra.contract_loaders.binary_loader import BinaryLoader
+from dolabra.contract_loaders.runtime_loader import RuntimeLoader
 
 from dolabra.constants import TIMEOUT, MAX_DEPTH, BOUNDED_LOOPS_LIMIT
 
@@ -36,42 +40,68 @@ class SymbolicWrapper:
     def _process_contract(self):
         contract = self.contract
         bytecode = None
+        runtime = None
         contract_address = None
         dyn_loader = None
 
         if contract is not None:
-            if isinstance(contract, FileLoader):
+            if isinstance(contract, BinaryLoader):
                 bytecode = contract.contract().creation_disassembly.bytecode
+            elif isinstance(contract, RuntimeLoader):
+                contract_address = "0"
+                runtime = contract.contract().disassembly
             elif isinstance(contract, JsonRpcLoader):
                 contract_address = contract.address
                 dyn_loader = contract.dyn_loader
             else:
                 raise ValueError('Invalid type for contract parameter')
 
-        return bytecode, contract_address, dyn_loader
+        return bytecode, runtime, contract_address, dyn_loader
 
-    def _initialize_laser(self, timeout, max_depth, creation_code, target_address, dyn_loader):
-        world_state = None
 
-        if creation_code is not None and target_address is None:
-            log.info('Initializing symbolic execution for contract creation...')
-            laser = svm.LaserEVM(execution_timeout=timeout,
-                                 max_depth=max_depth, requires_statespace=False)
+    
+    def _initialize_laser(self, timeout, max_depth, creation_code, runtime_code, target_address, dyn_loader):
+        world_state = WorldState()
 
-        elif creation_code is None and target_address is not None:
+        if creation_code and not runtime_code and not target_address:
+            log.info('Initializing symbolic execution of creation code')
+            laser = svm.LaserEVM(
+                execution_timeout=timeout,
+                max_depth=max_depth,
+                requires_statespace=False)
+
+        elif runtime_code and not creation_code:
+            assert target_address
+            log.info('Initializing symbolic execution of runtime code')
+            account = mythril.laser.ethereum.state.account.Account(
+                "0",
+                runtime_code,
+                contract_name="MAIN",
+                balances=world_state.balances,
+                concrete_storage=False)
+            world_state.put_account(account)
+            laser = svm.LaserEVM(
+                execution_timeout=timeout,
+                max_depth=max_depth,
+                requires_statespace=False)
+
+        elif target_address and not runtime_code and not creation_code:
             assert dyn_loader is not None, "Dynamic Loader has not been provided"
-            log.info('Initializing symbolic execution for an existing contract...')
-            world_state = WorldState()
+            log.info('Initializing symbolic execution of an existing contract')
             world_state.accounts_exist_or_load(target_address, dyn_loader)
-            laser = svm.LaserEVM(dynamic_loader=dyn_loader, execution_timeout=timeout,
-                                 max_depth=max_depth, requires_statespace=False)
+            laser = svm.LaserEVM(
+                dynamic_loader=dyn_loader,
+                execution_timeout=timeout,
+                max_depth=max_depth,
+                requires_statespace=False)
 
         else:
-            raise ValueError(
-                'Either creation_code or target_address needs to be provided')
+            raise ValueError('Exactly one of creation_code, runtime_code and target_address needs to be provided')
 
         return laser, world_state
 
+
+    
     def _register_hooks_and_load_plugins(self, laser, bounded_loops_limit):
         log.info('Registering hooks and loading plugins...')     
 
@@ -98,8 +128,9 @@ class SymbolicWrapper:
                        contract_name='Unknown',
                        world_state=world_state,
                        target_address=int(target_address, 16) if target_address else None)
-        log.info('Symbolic execution finished in %.2f seconds.',
-                 time.time() - start_time)
+        log.info(
+            'Symbolic execution finished in %.2f seconds.',
+            time.time() - start_time)
         #return start_time, time.time()
 
         report = []
@@ -108,22 +139,27 @@ class SymbolicWrapper:
 
         return report    
 
+
+    
     def run_analysis(self):
         log.info('Processing the contract and preparing for analysis...')
-        bytecode, contract_address, dyn_loader = self._process_contract()
+        bytecode, runtime, contract_address, dyn_loader = self._process_contract()
 
-        laser, world_state = self._initialize_laser(timeout=TIMEOUT,
-                                                    max_depth=MAX_DEPTH,
-                                                    creation_code=bytecode,
-                                                    target_address=contract_address,
-                                                    dyn_loader=dyn_loader)
+        laser, world_state = self._initialize_laser(
+            timeout=TIMEOUT,
+            max_depth=MAX_DEPTH,
+            creation_code=bytecode,
+            runtime_code=runtime,
+            target_address=contract_address,
+	    dyn_loader=dyn_loader)
 
         self._register_hooks_and_load_plugins(laser, bounded_loops_limit=BOUNDED_LOOPS_LIMIT)
 
-        report = self._run_symbolic_execution(laser,
-                                                            creation_code=bytecode,
-                                                            target_address=contract_address,
-                                                            world_state=world_state)
+        report = self._run_symbolic_execution(
+            laser,
+            creation_code=bytecode,
+            target_address=contract_address,
+            world_state=world_state)
 
         # report = Report(start_time=start_time, end_time=end_time)
 

--- a/dolabra/contract_loaders/loader.py
+++ b/dolabra/contract_loaders/loader.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from dolabra.contract_loaders.contract_loader import ContractLoader
 from dolabra.contract_loaders.binary_loader import BinaryLoader
+from dolabra.contract_loaders.runtime_loader import RuntimeLoader
 from dolabra.contract_loaders.solidity_loader import SolidityLoader
 from dolabra.contract_loaders.jsonrpc_loader import JsonRpcLoader
 
@@ -9,11 +10,13 @@ class LoaderType(Enum):
     BINARY = 1
     SOLIDITY = 2
     JSON_RPC = 3
+    RUNTIME = 4
 
 class Loader():
     def get_contract(loader_type: LoaderType, **options) -> ContractLoader:
         switcher = {
             LoaderType.BINARY:   BinaryLoader.create,
+            LoaderType.RUNTIME:  RuntimeLoader.create,
             LoaderType.SOLIDITY: SolidityLoader.create,
             LoaderType.JSON_RPC: JsonRpcLoader.create
         }


### PR DESCRIPTION
This commits adds an option `-r` to process runtime bytecode. Use it like `dolabra analyze -r contract.hex`.
A second change concerns the initialization of Mythril. It seems that recent versions require that `mythril.support.support_args.args.pruning_factor` is set. For older versions of Mythril, the function `dolabra/cli/main.py:init_mythril` may fail; in this case, remove it.